### PR TITLE
Minor UI Improvements

### DIFF
--- a/src/main/resources/assets/deathlog/owo_ui/deathlog.xml
+++ b/src/main/resources/assets/deathlog/owo_ui/deathlog.xml
@@ -97,10 +97,12 @@
                             </children>
 
                             <sizing>
+                                <horizontal method="fill">60</horizontal>
                                 <vertical method="fill">100</vertical>
                             </sizing>
 
                             <vertical-alignment>center</vertical-alignment>
+                            <horizontal-alignment>center</horizontal-alignment>                                
                         </flow-layout>
                     </children>
 
@@ -142,7 +144,13 @@
                                 <text>{{death-time}}</text>
                                 <cursor-style>hand</cursor-style>
                             </label>
-
+                                
+                            <flow-layout direction="vertical">
+                                <sizing>
+                                    <vertical method="fixed">3</vertical> <!-- Adjust height for the gap -->
+                                </sizing>
+                            </flow-layout>
+                                
                             <label>
                                 <text>{{death-message}}</text>
                                 <cursor-style>hand</cursor-style>


### PR DESCRIPTION
Centered the "no_info_selected_hint" in its own area rather than centering with respect to the whole window.

Added some gap between the death-message and the death-time inside the death-list-entry-container to make it look more elegant.

![Screenshot 2025-03-13 204705](https://github.com/user-attachments/assets/5f499789-1ba2-431a-bf0b-5a47671bd84b)